### PR TITLE
Fix typo in spec description

### DIFF
--- a/spec/xmp_toolkit_ruby_spec.rb
+++ b/spec/xmp_toolkit_ruby_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe XmpToolkitRuby do
     expect(actual_xml.to_s).to eq(expected_xml.to_s)
   end
 
-  it "can ovverride existing XMP data" do
+  it "can override existing XMP data" do
     new_xmp = <<~XMP
         <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 6.0.0">
         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">


### PR DESCRIPTION
## Summary
- fix `ovverride` typo in spec

## Testing
- `bundle exec rspec` *(fails: bundler can't find gems)*

------
https://chatgpt.com/codex/tasks/task_e_68419ae4e7b483318f1c188f5a6462ec